### PR TITLE
Detaching d3-legend code from d3 object

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,1 @@
-var d3 = require('d3'),
-d3.legend = require('./no-extend')
-
-module.exports = d3;
+module.exports = require('./no-extend');

--- a/src/color.js
+++ b/src/color.js
@@ -1,4 +1,5 @@
 var helper = require('./legend');
+var d3 = require('d3');
 
 module.exports = function(){
 

--- a/src/size.js
+++ b/src/size.js
@@ -1,4 +1,5 @@
 var helper = require('./legend');
+var d3 = require('d3');
 
 module.exports =  function(){
 

--- a/src/symbol.js
+++ b/src/symbol.js
@@ -1,4 +1,5 @@
 var helper = require('./legend');
+var d3 = require('d3');
 
 module.exports = function(){
 


### PR DESCRIPTION
Two problems fixed here, at the expense of deviating from the upstream codebase:
- requiring d3 object in depending modules, resolving an undefined d3 ref in compiled code
- detaching legend property from d3 object and exporting the legend object to avoid creating a nearly identical and unnecessary additional d3 object in memory
